### PR TITLE
Feature: add db to development docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Dotenv
+api/.env

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,12 @@
-FROM node:alpine
+FROM node:12-alpine
 
 RUN apk update
 RUN apk add bash vim
+
+run apk --no-cache add --virtual native-deps \
+  g++ gcc libgcc libstdc++ linux-headers make python3 && \
+  npm install --quiet node-gyp -g &&\
+  npm install --quiet
 
 ARG node_env_var=production
 ENV NODE_ENV $node_env_var
@@ -16,6 +21,9 @@ WORKDIR /opt/app
 
 COPY ./package.json /opt/app
 RUN npm install
+
+RUN apk del native-deps
+
 COPY . /opt/app
 
 COPY ./docker-entrypoint.sh /opt/app

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -7,10 +7,19 @@ services:
     environment:
       - JWT_SECRET=secret
       - SESSION_SECRET=secret
-      - DB_HOST=host.docker.internal
+      - DB_HOST=db
       - DB_PORT=5432
-      - DB_USERNAME=root
-      - DB_PASSWORD=root
+      - DB_USERNAME=corona
+      - DB_PASSWORD=corona
       - DB_DATABASE=corona
-      - DB_READ_REPLICA_HOST=host.docker.internal
+      - DB_READ_REPLICA_HOST=db
       - API_TOKEN=token
+    depends_on:
+      - db
+
+  db:
+    image: postgres:alpine
+    restart: always
+    environment:
+      POSTGRES_USER: corona
+      POSTGRES_PASSWORD: corona

--- a/api/src/config/default.js
+++ b/api/src/config/default.js
@@ -2,12 +2,12 @@ module.exports = {
     jwtSecret: "secret",
     sessionSecret: "topsecret",
     postgres: {
-        host: "localhost",
-        port: "5432",
-        username: "postgres",
-        password: "root",
-        database: "corona",
-        readReplicaHost: "localhost"
+        host: process.env.DB_HOST || "localhost",
+        port: process.env.DB_PORT || "5432",
+        username: process.env.DB_USERNAME || "postgres",
+        password: process.env.DB_PASSWORD || "root",
+        database: process.env.DB_DATABASE || "corona",
+        readReplicaHost: process.env.DB_READ_REPLICA_HOST || "localhost"
     },
     apiToken: "token"
 };


### PR DESCRIPTION
Instead of using the hacky host.docker.internal interface, which depends on a DB to be set up by the developer on their machine.

This is the first of a number of improvement PRs I have in mind.

We need to discuss if this is agreeable to merge these into our local fork, or if there's a want to also merge to the kikukiks/coronatest upstream